### PR TITLE
Fix termination condition for JobDriver::read.

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -88,7 +88,7 @@ impl<R: BufRead> Read for JobDriver<R> {
         let mut out_cap = buf.len();
 
         loop {
-            let (read, written) = {
+            let (res, read, written) = {
                 let readbuf = try!(self.input.fill_buf());
                 let cap = readbuf.len();
                 if cap == 0 {
@@ -104,7 +104,7 @@ impl<R: BufRead> Read for JobDriver<R> {
                 }
                 let read = cap - buffers.available_input();
                 let written = out_cap - buffers.available_output();
-                (read, written)
+                (res, read, written)
             };
 
             // update read size
@@ -112,7 +112,7 @@ impl<R: BufRead> Read for JobDriver<R> {
             // update write size
             out_pos += written;
             out_cap -= written;
-            if out_cap == 0 || written == 0 {
+            if out_cap == 0 || res == raw::RS_DONE {
                 return Ok(out_pos);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -579,4 +579,14 @@ mod test {
         });
         t.join().unwrap();
     }
+
+    #[test]
+    fn trivial_large_file() {
+        let data = vec![0; 65536];
+        let mut sig = Signature::with_options(Cursor::new(&data), 16384, 5, SignatureType::MD4).unwrap();
+        let delta = Delta::new(Cursor::new(&data), &mut sig).unwrap();
+        let mut computed_new = vec![];
+        Patch::new(Cursor::new(&data), delta).unwrap().read_to_end(&mut computed_new).unwrap();
+        assert_eq!(computed_new, data);
+    }
 }


### PR DESCRIPTION
It's legal for librsync to write nothing but still not be finished yet. This can happen when processing large blocks.