### PR TITLE
Bump librsync-sys version from 0.1.2 to 0.1.3

### DIFF
--- a/librsync-sys/Cargo.toml
+++ b/librsync-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "librsync-sys"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Michele Bertasi <@brt_device>"]
 build = "build.rs"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
This is needed because fix 3dbc9b7e5131546503aefcfc3c24c17f93541d92 is not available in cargo!
The first commit matching version 0.1.2 is used, and compilation always fails.

This fix is rather urgent and trivial